### PR TITLE
TOOLS-2897 Add codeowners workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+name: CI
+
+on: push
+
+jobs:
+  shared-workflow:
+    uses: scribd/github-actions-shared-workflows/.github/workflows/shared-workflow.yml@main
+    secrets:
+      github_access_token: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,9 +1,0 @@
-name: Codeowners
-
-on: push
-
-jobs:
-  codeowners:
-    uses: scribd/github-actions-shared-workflows/.github/workflows/codeowners-workflow.yml@main
-    secrets:
-      github_access_token: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,0 +1,9 @@
+name: Codeowners
+
+on: push
+
+jobs:
+  codeowners:
+    uses: scribd/github-actions-shared-workflows/.github/workflows/codeowners-workflow.yml@main
+    secrets:
+      github_access_token: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}


### PR DESCRIPTION
## Description

This is part of the ITGC initiative ensuring all business-critical repos are compliant. The codeowners-validator must be present to ensure the integrity of the code review process

- Adds codeowners-validator to workflow

## Jira Ticket

https://scribdjira.atlassian.net/browse/TOOLS-2897

## Testing Considerations

- [x] See github actions workflow